### PR TITLE
Create Rake Task to Import from CSV

### DIFF
--- a/lib/tasks/seed_from_csv.rake
+++ b/lib/tasks/seed_from_csv.rake
@@ -5,12 +5,53 @@ end
 
 task seed_from_csv: :environment do
   require 'csv'
-  'db:reset'
-  Dir.foreach('db/csv_seeds') do |csv|
-    if csv != "." && csv != ".."
-      CSV.foreach("db/csv_seeds/#{csv}", headers: true) do |row|
-        require 'pry'; binding.pry
-      end
-    end
+
+  # silence_stream(STDOUT) do
+  #   Rake::Task['db:reset'].invoke
+  # end
+  system "rake db:reset > /dev/null"
+  # Transaction.delete_all
+  # InvoiceItem.delete_all
+  # Invoice.delete_all
+  # Item.delete_all
+  # Customer.delete_all
+  # Merchant.delete_all
+
+  CSV.foreach('db/csv_seeds/customers.csv', headers: true) do |row|
+    customer = Customer.new(row.to_hash)
+    customer.id = row[0]
+    customer.save
   end
+  puts 'Customers Seeded'
+
+  CSV.foreach('db/csv_seeds/merchants.csv', headers: true) do |row|
+    Merchant.create(row.to_hash)
+  end
+  puts 'Merchants Seeded'
+
+  CSV.foreach('db/csv_seeds/items.csv', headers: true) do |row|
+    Item.create(row.to_hash)
+  end
+  puts 'Items Seeded'
+
+  CSV.foreach('db/csv_seeds/invoices.csv', headers: true) do |row|
+    Invoice.create(row.to_hash)
+  end
+
+  CSV.foreach('db/csv_seeds/invoice_items.csv', headers: true) do |row|
+    InvoiceItem.create(row.to_hash)
+  end
+  puts 'Invoices Seeded'
+
+  CSV.foreach('db/csv_seeds/transactions.csv', headers: true) do |row|
+    Transaction.create(row.to_hash)
+  end
+  puts 'Transactions Seeded'
+  # Dir.foreach('db/csv_seeds') do |csv|
+  #   if csv != "." && csv != ".."
+  #     CSV.foreach("db/csv_seeds/#{csv}", headers: true) do |row|
+  #       require 'pry'; binding.pry
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
Enable a rake command to pull from six files in the db/csv_seeds folder.
Files are imported in a specific order (Customer, Merchant, Items, Invoices, Invoice_Items, Transaction) to maintain relationships.

This rake command also resets the db based on the current schema to prevent data duplication.

**THIS DOES NOT RUN MIGRATIONS ONLY USES THE CURRENT SCHEMA**